### PR TITLE
feat: make initialize re-callable with new admin + move accepted_mint…

### DIFF
--- a/sdk/src/idl/payment_processor.json
+++ b/sdk/src/idl/payment_processor.json
@@ -10,11 +10,7 @@
     {
       "name": "initialize",
       "docs": [
-        "One-time program initialization by the admin.",
-        "",
-        "* `accepted_mint`  – SPL-Token mint that the program will accept as payment.",
-        "* `prompt_price`   – Reference price for a single prompt, expressed in the *accepted",
-        "mint’s smallest units (no oracle look-ups for now)."
+        "One-time program initialization by the admin."
       ],
       "discriminator": [
         175,
@@ -54,7 +50,7 @@
           }
         },
         {
-          "name": "admin",
+          "name": "authority",
           "writable": true,
           "signer": true
         },
@@ -65,12 +61,8 @@
       ],
       "args": [
         {
-          "name": "accepted_mint",
+          "name": "new_admin",
           "type": "pubkey"
-        },
-        {
-          "name": "prompt_price",
-          "type": "u64"
         }
       ]
     },
@@ -276,6 +268,10 @@
           "type": "u64"
         },
         {
+          "name": "accepted_mint",
+          "type": "pubkey"
+        },
+        {
           "name": "agent_token",
           "type": "pubkey"
         }
@@ -358,6 +354,11 @@
       "code": 6003,
       "name": "PriceMismatch",
       "msg": "Provided price does not match operation price"
+    },
+    {
+      "code": 6004,
+      "name": "Unauthorized",
+      "msg": "Caller is not authorized to modify the global config"
     }
   ],
   "types": [
@@ -369,14 +370,6 @@
           {
             "name": "admin",
             "type": "pubkey"
-          },
-          {
-            "name": "accepted_mint",
-            "type": "pubkey"
-          },
-          {
-            "name": "prompt_price",
-            "type": "u64"
           },
           {
             "name": "bump",
@@ -401,6 +394,10 @@
           {
             "name": "payment_amount",
             "type": "u64"
+          },
+          {
+            "name": "accepted_mint",
+            "type": "pubkey"
           },
           {
             "name": "agent_token",

--- a/sdk/src/idl/payment_processor.ts
+++ b/sdk/src/idl/payment_processor.ts
@@ -16,11 +16,7 @@ export type PaymentProcessor = {
     {
       "name": "initialize",
       "docs": [
-        "One-time program initialization by the admin.",
-        "",
-        "* `accepted_mint`  – SPL-Token mint that the program will accept as payment.",
-        "* `prompt_price`   – Reference price for a single prompt, expressed in the *accepted",
-        "mint’s smallest units (no oracle look-ups for now)."
+        "One-time program initialization by the admin."
       ],
       "discriminator": [
         175,
@@ -60,7 +56,7 @@ export type PaymentProcessor = {
           }
         },
         {
-          "name": "admin",
+          "name": "authority",
           "writable": true,
           "signer": true
         },
@@ -71,12 +67,8 @@ export type PaymentProcessor = {
       ],
       "args": [
         {
-          "name": "acceptedMint",
+          "name": "newAdmin",
           "type": "pubkey"
-        },
-        {
-          "name": "promptPrice",
-          "type": "u64"
         }
       ]
     },
@@ -282,6 +274,10 @@ export type PaymentProcessor = {
           "type": "u64"
         },
         {
+          "name": "acceptedMint",
+          "type": "pubkey"
+        },
+        {
           "name": "agentToken",
           "type": "pubkey"
         }
@@ -364,6 +360,11 @@ export type PaymentProcessor = {
       "code": 6003,
       "name": "priceMismatch",
       "msg": "Provided price does not match operation price"
+    },
+    {
+      "code": 6004,
+      "name": "unauthorized",
+      "msg": "Caller is not authorized to modify the global config"
     }
   ],
   "types": [
@@ -375,14 +376,6 @@ export type PaymentProcessor = {
           {
             "name": "admin",
             "type": "pubkey"
-          },
-          {
-            "name": "acceptedMint",
-            "type": "pubkey"
-          },
-          {
-            "name": "promptPrice",
-            "type": "u64"
           },
           {
             "name": "bump",
@@ -407,6 +400,10 @@ export type PaymentProcessor = {
           {
             "name": "paymentAmount",
             "type": "u64"
+          },
+          {
+            "name": "acceptedMint",
+            "type": "pubkey"
           },
           {
             "name": "agentToken",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,14 +37,11 @@ export default {
             );
         }
 
-        async function initialize(args: {
-            acceptedMint: PublicKey;
-            promptPrice: anchor.BN;
-        }): Promise<{ signature: string; globalConfigPda: PublicKey }> {
+        async function initialize(newAdmin: PublicKey): Promise<{ signature: string; globalConfigPda: PublicKey }> {
             const [globalConfigPda] = getGlobalConfigPda();
 
             const signature = await program.methods
-                .initialize(args.acceptedMint, args.promptPrice)
+                .initialize(newAdmin)
                 .accountsStrict({
                     globalConfig: globalConfigPda,
                     admin: payer,
@@ -59,6 +56,7 @@ export default {
             paymentType: number;
             name: string;
             paymentAmount: anchor.BN;
+            acceptedMint: PublicKey;
             agentToken: PublicKey;
         }): Promise<{ signature: string; operationPda: PublicKey }> {
             const [operationPda] = getOperationPda(args.paymentType);
@@ -69,6 +67,7 @@ export default {
                     new anchor.BN(args.paymentType),
                     args.name,
                     args.paymentAmount,
+                    args.acceptedMint,
                     args.agentToken,
                 )
                 .accountsStrict({
@@ -90,10 +89,10 @@ export default {
             userPaymentToken?: PublicKey;
             receiverToken?: PublicKey;
         }): Promise<{ signature: string }> {
-            const { globalConfig } = await getGlobalConfig();
-            if (!globalConfig) throw new Error("GlobalConfig not found");
+            const { operation } = await getOperation(args.paymentType);
+            if (!operation) throw new Error("Operation not found");
 
-            const acceptedMint = globalConfig.acceptedMint as PublicKey;
+            const acceptedMint = operation.acceptedMint as PublicKey;
             const agentWallet = args.agentWallet;
 
             const userToken =


### PR DESCRIPTION
… to operations

- `initialize` is now upgradeable: accepts `new_admin` and checks caller matches current admin
- removed `accepted_mint` from global config; now each operation specifies its own accepted mint
- updated `set_operation` to accept `accepted_mint`
- `pay` validates token mints against the operation's accepted_mint
- updated SDK and test suite to reflect changes
- added test to verify reinitialization with same admin